### PR TITLE
Declare variables used to load assets

### DIFF
--- a/plugin/jw_sig.php
+++ b/plugin/jw_sig.php
@@ -195,6 +195,11 @@ class plgContentJw_sig extends JPlugin {
 					$extraWrapperClass = '';
 					$legacyHeadIncludes = '';
 					$customLinkAttributes = '';
+					// Declare variables used later
+					$stylesheets = null;
+					$stylesheetDeclarations = null;
+					$scripts = null;
+					$scriptDeclarations = null;
 
 					$popupPath = "{$pluginLivePath}/includes/js/{$popup_engine}";
 					$popupRequire = dirname(__FILE__).DS.$this->plg_name.DS.'includes'.DS.'js'.DS.$popup_engine.DS.'popup.php';


### PR DESCRIPTION
In case these variables are not set by the popup engine but checked later using `count` function, PHP logs warnings like 

```
Notice: Undefined variable: stylesheets
Notice: Undefined variable: stylesheetDeclarations
Notice: Undefined variable: scripts
Notice: Undefined variable: scriptDeclarations
```
